### PR TITLE
fix(realtime_kernel): Correctly remount `/boot` in `rw` mode

### DIFF
--- a/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
@@ -7,8 +7,7 @@
 - name: Remount /boot partition in read-write mode (if separate)
   ansible.posix.mount:
     path: /boot
-    src: '{{ boot_device.stdout }}'
-    state: ephemeral
+    state: remounted
     fstype: auto
     opts: rw
   changed_when: false # Required for molecule idempotence check
@@ -53,5 +52,4 @@
   when: realtime_kernel_grep_boot.rc == 0
   ansible.posix.mount:
     path: /boot
-    state: ephemeral
-    opts: ro
+    state: remounted


### PR DESCRIPTION
The `boot_device` variable wasn't defined. Also, using `remounted` as state
works better:

> `remounted` specifies that the device will be remounted for when you want to force a refresh on the mount itself.
  This will always return changed=true.
  If opts is set, the options will be applied to the remount, but will not change fstab.

Remounting the device without the `opts` mounts it in the same mode as defined in the `/etc/fstab` file.
