### PR TITLE
refactor(realtime_kernel): Improve role `realtime_kernel`

### DIFF
--- a/molecule/realtime_kernel/tests/test_realtime_kernel.py
+++ b/molecule/realtime_kernel/tests/test_realtime_kernel.py
@@ -11,3 +11,11 @@ def test_only_realtime_kernel_is_installed(host: Host) -> None:
     assert len(menu_entries) > 0, "No menu entries found in grub configuration."
     for match in menu_entries:
         assert "rt-amd64" in match.group("kernel")
+
+
+def test_realtime_kernel_is_loaded(host: Host) -> None:
+    kernel_cmd = host.run("uname -r")
+    assert kernel_cmd.rc == 0
+    assert kernel_cmd.stdout.strip().endswith(
+        "rt-amd64"
+    ), f"Loaded kernel is not a realtime kernel: {kernel_cmd.stdout}"

--- a/voraus/ipc_tools/roles/realtime_kernel/defaults/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+realtime_kernel_apt_packages:
+  - linux-image-rt-amd64
+  - linux-headers-rt-amd64

--- a/voraus/ipc_tools/roles/realtime_kernel/handlers/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Update GRUB # noqa no-changed-when
+  ansible.builtin.command: update-grub2
+
+- name: Reboot Machine
+  ansible.builtin.reboot:

--- a/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
@@ -1,57 +1,52 @@
-- name: Check if /boot is present in df -h output
-  ansible.builtin.shell: df -h | grep -q ' /boot$' # Returns 0 if /boot is mounted separately, 1 otherwise.
-  register: realtime_kernel_grep_boot
-  ignore_errors: true
-  changed_when: false
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
 
-- name: Remount /boot partition in read-write mode (if separate)
-  ansible.posix.mount:
-    path: /boot
-    src: '{{ boot_device.stdout }}'
-    state: ephemeral
-    fstype: auto
-    opts: rw
-  changed_when: false # Required for molecule idempotence check
-  when: realtime_kernel_grep_boot.rc == 0
+- name: Set fact for non-rt linux-image and linux-headers packages
+  ansible.builtin.set_fact:
+    realtime_kernel_non_rt_kernels: >-
+      {{
+        ansible_facts.packages | dict2items
+        | selectattr('key', 'match', '^(linux-image-|linux-headers-)')
+        | rejectattr('key', 'match', '.*rt.*')
+        | map(attribute='key') | list
+      }}
 
-- name: Install realtime kernel
-  ansible.builtin.apt:
-    update_cache: true
-    pkg:
-      - linux-image-rt-amd64
-      - linux-headers-rt-amd64
+- name: Run install/uninstall tasks
+  when: >-
+    realtime_kernel_apt_packages | reject('in', ansible_facts.packages.keys()) | list | length > 0
+    or
+    realtime_kernel_non_rt_kernels | length > 0
 
-- name: Remove non-rt kernel and header packages
+  notify:
+    - Update GRUB
+    - Reboot Machine
   block:
-    - name: List all installed linux-image and linux-headers packages
-      ansible.builtin.shell: |
-        set -euo pipefail
-        apt list --installed 'linux-image-*' 'linux-headers-*' 2>/dev/null \
-          | grep -v 'rt' \
-          | awk -F/ '/installed/ {print $1}' \
-          | tr '\n' ' '
-      args:
-        executable: /bin/bash
-      register: realtime_kernel_non_rt_kernels
-      changed_when: false # Required for molecule idempotence check
-      check_mode: false
+    - name: Check if /boot is mounted in read-only mode
+      # Returns 0 if /boot is mounted separately and in read-only mode, 1 otherwise.
+      ansible.builtin.shell: grep "[[:space:]]ro[[:space:],]" /proc/mounts | grep /boot
+      register: realtime_kernel_grep_boot
+      ignore_errors: true
+      changed_when: false
+
+    - name: Remount /boot partition in read-write mode if necessary
+      ansible.posix.mount:
+        path: /boot
+        state: remounted
+        fstype: auto
+        opts: rw
+      when: realtime_kernel_grep_boot.rc == 0
 
     - name: Remove non-rt kernel and header packages
       ansible.builtin.apt:
-        name: '{{ realtime_kernel_non_rt_kernels.stdout.split() }}'
+        name: '{{ realtime_kernel_non_rt_kernels }}'
         state: absent
         autoremove: true
         purge: true
-      when: realtime_kernel_non_rt_kernels.stdout != ""
+      when: realtime_kernel_non_rt_kernels | length > 0
 
-- name: Update GRUB
-  ansible.builtin.command: update-grub2
-  changed_when: false # Required for molecule idempotence check
-
-- name: Remount /boot partition in read-only mode
-  changed_when: false # Required for molecule idempotence check
-  when: realtime_kernel_grep_boot.rc == 0
-  ansible.posix.mount:
-    path: /boot
-    state: ephemeral
-    opts: ro
+    - name: Install realtime kernel
+      ansible.builtin.apt:
+        update_cache: true
+        pkg: '{{ realtime_kernel_apt_packages }}'
+      register: realtime_kernel_apt_install


### PR DESCRIPTION
- Define realtime kernel packages as variable
- Determine installed packges via `ansible.builtin.package_facts`
- Only remount `/boot` in `ro` mode if necessary
- Only install realtime kernel if not already installed
- Only update grub config if necessary
- Reboot host after realtime kernel installation
- Define reboot and update grub as handlers
- Add test that ensures that the realtime kernel is loaded after the reboot
- Purge non-realtime kernels before installing the realtime kernel. Otherwise, the non-realtime kernel stays installed for whatever reason.
    
Tested on two setups: with and without separate separate `/boot` mount