### PR TITLE
feat(example-playbook): Install `docker` per default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # Ansible Galaxy file. This is generated with the `make, make version resp tox run -r build command`
 galaxy.yml
 
+# Exclude local development inventory file
+inventory.yml
+
 # General
 output/
 .tox/

--- a/inventory.example.yml
+++ b/inventory.example.yml
@@ -4,3 +4,6 @@ all:
     ipc:
       ansible_host: 192.168.1.1
       ansible_user: root
+      ansible_password: voraus
+      docker_users:
+        - localuser

--- a/molecule/example-playbook/molecule.yml
+++ b/molecule/example-playbook/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    requirements-file: requirements.yml
 driver:
   name: vagrant
   provider:
@@ -15,8 +17,6 @@ platforms:
         type: 'dhcp'
 provisioner:
   name: ansible
-  env:
-    ANSIBLE_ROLES_PATH: ../../voraus/ipc_tools/roles/
   playbooks:
     converge: ../../voraus/ipc_tools/playbooks/example.yml
 verifier:

--- a/molecule/example-playbook/requirements.yml
+++ b/molecule/example-playbook/requirements.yml
@@ -1,4 +1,7 @@
 ---
+roles:
+  - name: geerlingguy.docker
+
 collections:
   - name: voraus.ipc_tools
     source: voraus/ipc_tools

--- a/molecule/example-playbook/tests/test_apt_packages.py
+++ b/molecule/example-playbook/tests/test_apt_packages.py
@@ -16,6 +16,9 @@ from testinfra.host import Host
         "gnupg2",
         "nmap",
         "tcpdump",
+        "docker-ce",
+        "docker-ce-cli",
+        "docker-compose-plugin",
     ],
 )
 def test_apt_packages(package: str, host: Host) -> None:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,4 @@
 ---
-roles: []
-
 collections:
   - name: community.general
   - name: ansible.posix

--- a/voraus/ipc_tools/playbooks/example.yml
+++ b/voraus/ipc_tools/playbooks/example.yml
@@ -6,6 +6,7 @@
   roles:
     - voraus.ipc_tools.realtime_kernel
     - voraus.ipc_tools.wibu_codemeter
+    - geerlingguy.docker
   tasks:
     - name: Install base packages
       ansible.builtin.package:


### PR DESCRIPTION
Using the [geerlingguy.docker](https://github.com/geerlingguy/ansible-role-docker) ansible role.

- Adds the `localuser` to the `docker` group as well