### PR TITLE
docs: Add intallation instruction for docker role to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ python3 -m venv venv
 source venv/bin/activate
 pip install ansible
 
+# Install the docker role
+ansible-galaxy role install geerlingguy.docker
+
 # Install the collection
 ansible-galaxy collection install voraus.ipc_tools
 ```


### PR DESCRIPTION
The instruction for installation of the docker role is added to the README.