### PR TITLE
fix(realtime_kernel): Run `update-grub2` if current kernel is non rt

### DIFF
--- a/voraus/ipc_tools/roles/realtime_kernel/handlers/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/handlers/main.yml
@@ -1,6 +1,3 @@
 ---
-- name: Update GRUB # noqa no-changed-when
-  ansible.builtin.command: update-grub2
-
 - name: Reboot Machine
   ansible.builtin.reboot:

--- a/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
+++ b/voraus/ipc_tools/roles/realtime_kernel/tasks/main.yml
@@ -17,9 +17,9 @@
     realtime_kernel_apt_packages | reject('in', ansible_facts.packages.keys()) | list | length > 0
     or
     realtime_kernel_non_rt_kernels | length > 0
-
+    or
+    '-rt-' not in ansible_kernel
   notify:
-    - Update GRUB
     - Reboot Machine
   block:
     - name: Check if /boot is mounted in read-only mode
@@ -50,3 +50,10 @@
         update_cache: true
         pkg: '{{ realtime_kernel_apt_packages }}'
       register: realtime_kernel_apt_install
+
+    - name: Update GRUB # noqa no-changed-when
+      when: >-
+        '-rt-' not in ansible_kernel
+        or
+        realtime_kernel_apt_install.changed
+      ansible.builtin.command: update-grub2


### PR DESCRIPTION
...or `apt` updated the kernel.

Before, if the playbook execution fails for some reasons after installing
the realtime kernel but before finishing all tasks, the `update-grub2`
command wasn't executed because the conditions did not met.