### PR TITLE
ci(sonarcloud)!: Drop `SonarCloud` configuration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.sources=src/voraus_ipc_tools_ansible
-sonar.tests=tests
-
-sonar.python.version=3.11
-sonar.python.coverage.reportPaths=reports/coverage.xml
-sonar.python.xunit.reportPath=reports/pytest.xml


### PR DESCRIPTION
As decided in the last TB, we want to stop using SonarCloud for the
majority of our projects since most langauges/pipelines have enough tooling
(e.g. ruff, ...) to enforce coding best practices and the cost and
maintenance overhead of SonarCloud are too high.

This resolves [ESPRIT-1978].

[ESPRIT-1978]: https://vorausrobotik.atlassian.net/browse/ESPRIT-1978