### PR TITLE
feat: Rotate wibu repo to JFrog Artifactory and bump package versions

### DIFF
--- a/molecule/wibu_packages/molecule.yml
+++ b/molecule/wibu_packages/molecule.yml
@@ -16,14 +16,28 @@ platforms:
     networks:
       - name: 'public_network'
         type: 'dhcp'
+  - name: wibu-packages-old-repo-present
+    box: cloud-image/debian-13
+    memory: 1024
+    cpus: 1
+    networks:
+      - name: 'public_network'
+        type: 'dhcp'
 provisioner:
   name: ansible
   inventory:
     group_vars:
       all:
         role_name: voraus.ipc_tools.wibu_packages
+    host_vars:
+      # Clean machine without the old repo/key
+      wibu-packages-test:
+        wibu_packages_provision_old_repo: false
+      # Machine pre-provisioned with the old wibu repo and GPG key
+      wibu-packages-old-repo-present:
+        wibu_packages_provision_old_repo: true
   playbooks:
-    prepare: ../shared/prepare.yml
+    prepare: prepare.yml
     converge: ../shared/converge.yml
 verifier:
   name: testinfra

--- a/molecule/wibu_packages/prepare.yml
+++ b/molecule/wibu_packages/prepare.yml
@@ -1,0 +1,35 @@
+---
+- name: Import shared prepare playbook
+  ansible.builtin.import_playbook: ../shared/prepare.yml
+
+- name: Provision old wibu apt repo and GPG key
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Install dependencies for old repo provisioning
+      ansible.builtin.apt:
+        pkg:
+          - gnupg2
+          - curl
+        state: present
+        update_cache: true
+      when: wibu_packages_provision_old_repo | default(false)
+
+    - name: Download and dearmor old wibu GPG key
+      ansible.builtin.shell: |
+        set -o pipefail
+        curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/wibu-packages-maintainers.gpg | \
+        gpg --dearmor -o /usr/share/keyrings/wibu-package-maintainers.gpg
+      args:
+        executable: /bin/bash
+        creates: /usr/share/keyrings/wibu-package-maintainers.gpg
+      when: wibu_packages_provision_old_repo | default(false)
+
+    - name: Add old wibu apt repo
+      ansible.builtin.apt_repository:
+        repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
+        filename: voraus-wibu
+        state: present
+        update_cache: true
+      when: wibu_packages_provision_old_repo | default(false)

--- a/molecule/wibu_packages/tests/test_wibu_packages.py
+++ b/molecule/wibu_packages/tests/test_wibu_packages.py
@@ -5,7 +5,7 @@ from testinfra.modules.package import Package
 
 @pytest.mark.parametrize(
     ("package_name", "package_version"),
-    [("codemeter-lite", "8.20.6539.500"), ("axprotector", "11.70.7131.502")],
+    [("codemeter-lite", "9.0.8031.500"), ("axprotector", "11.80.8031.500")],
 )
 def test_packages_installed(package_name: str, package_version: str, host: Host) -> None:
     package: Package = host.package(package_name)
@@ -18,3 +18,10 @@ def test_codemeter_listens(host: Host) -> None:
     # If you don’t specify a host for udp and tcp sockets, then the socket is listening if and only if the socket
     # listens on both all ipv4 and ipv6 addresses (ie 0.0.0.0 and ::)
     assert host.socket("tcp://22350").is_listening
+
+
+def test_old_repo_and_key_removed(host: Host) -> None:
+    # The role must clean up the rotated-out wibu repo and GPG key, including on
+    # machines that were previously provisioned with them.
+    assert not host.file("/usr/share/keyrings/wibu-package-maintainers.gpg").exists
+    assert not host.file("/etc/apt/sources.list.d/voraus-wibu.list").exists

--- a/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 wibu_packages_install:
-  codemeter-lite: 8.20.6539.500
-  axprotector: 11.70.7131.502
+  codemeter-lite: 9.0.8031.500
+  axprotector: 11.80.8031.500
 
 wibu_packages_allow_downgrades: true
 

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/add_voraus_repo.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/add_voraus_repo.yml
@@ -1,0 +1,32 @@
+---
+# Debian 13+ deprecates one-line .list sources in favor of the deb822 .sources
+# format, so use deb822_repository there and apt_repository on older releases.
+- name: Determine whether to use the deb822 sources format
+  ansible.builtin.set_fact:
+    wibu_packages_use_deb822: "{{ ansible_distribution == 'Debian' and ansible_distribution_major_version is version('13', '>=') }}"
+
+- name: Add voraus packages apt repo (deb822 format)
+  ansible.builtin.deb822_repository:
+    name: voraus
+    types: deb
+    uris: https://voraus.jfrog.io/artifactory/debian
+    suites: stable
+    components: main
+    architectures: amd64
+    signed_by: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+    state: present
+  when: wibu_packages_use_deb822
+  register: wibu_packages_deb822_repo
+
+- name: Update apt cache after adding deb822 repo # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: wibu_packages_deb822_repo is changed
+
+- name: Add voraus packages apt repo (one-line format)
+  ansible.builtin.apt_repository:
+    repo: 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/vorausrobotik.gpg] https://voraus.jfrog.io/artifactory/debian stable main'
+    filename: voraus
+    state: present
+    update_cache: true
+  when: not wibu_packages_use_deb822

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/cleanup_old_repo.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/cleanup_old_repo.yml
@@ -1,0 +1,12 @@
+---
+- name: Remove old wibu apt repo
+  ansible.builtin.apt_repository:
+    repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
+    filename: voraus-wibu
+    state: absent
+    update_cache: true
+
+- name: Remove old wibu GPG key
+  ansible.builtin.file:
+    path: /usr/share/keyrings/wibu-package-maintainers.gpg
+    state: absent

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/install_codemeter.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/install_codemeter.yml
@@ -26,8 +26,6 @@
     option: '{{ item.option }}'
     value: '{{ item.value }}'
     ignore_spaces: true
-    owner: daemon
-    group: daemon
     mode: '0644'
   with_items:
     - section: General

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/main.yml
@@ -7,21 +7,20 @@
       - curl
     state: present
 
-- name: Download and dearmor wibu GPG key
+- name: Clean up old wibu apt repo and GPG key
+  ansible.builtin.include_tasks: cleanup_old_repo.yml
+
+- name: Download and dearmor voraus GPG key
   ansible.builtin.shell: |
     set -o pipefail
-    curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/wibu-packages-maintainers.gpg | \
-    gpg --dearmor -o /usr/share/keyrings/wibu-package-maintainers.gpg
+    curl -s --compressed https://voraus.jfrog.io/ui/api/v1/ui/security/keyPairs/voraus-gpg/public | \
+    gpg --dearmor -o /etc/apt/trusted.gpg.d/vorausrobotik.gpg
   args:
     executable: /bin/bash
-    creates: /usr/share/keyrings/wibu-package-maintainers.gpg
+    creates: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
 
-- name: Add wibu packages apt repo
-  ansible.builtin.apt_repository:
-    repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
-    filename: voraus-wibu
-    state: present
-    update_cache: true
+- name: Add voraus packages apt repo
+  ansible.builtin.include_tasks: add_voraus_repo.yml
 
 - name: Include package specific tasks
   ansible.builtin.include_tasks: 'install_{{ package_mapping[item.key] }}.yml'


### PR DESCRIPTION
Move the wibu_packages role from the old `wibu-packages.vorausrobotik.com`
apt repo to the JFrog Artifactory Debian repo with the rotated GPG key.

- Install the new voraus GPG key at `/etc/apt/trusted.gpg.d/vorausrobotik.gpg`
- Add the new repo as the `voraus` sources file (On debian 13 or newer in `deb822` format)
- Remove the old `voraus-wibu` repo and `wibu-package-maintainers.gpg` key
  via a dedicated cleanup_old_repo task file
- Bump codemeter-lite to `9.0.8031.500` and axprotector to `11.80.8031.500`
- Remove `owner/group` from CodeMeter `Server.ini` file (mode `0644` keeps it unchanged)

Add a molecule machine pre-provisioned with the old repo/key and a test
asserting both are removed after the role runs.
