### PR TITLE
feat(wibu_packages): Restrict access to the CodeMeter ports

### DIFF
--- a/molecule/example_playbook/molecule.yml
+++ b/molecule/example_playbook/molecule.yml
@@ -24,6 +24,21 @@ provisioner:
     group_vars:
       all:
         core_isolation_isolated_core_ids: [1, 3]
+        # The example playbook applies the firewall with the role defaults
+        wibu_packages_firewall: true
+        # Remote sources for the firewall tests, provisioned by `../shared/side_effect.yml`
+        wibu_packages_firewall_probes:
+          - namespace: cm-container
+            interface: br-molecule
+            host_address: 10.99.1.1
+            peer_address: 10.99.1.2
+            # Simulates a container, so it may reach the licensing port
+            licensing_allowed: true
+          - namespace: cm-external
+            interface: ext-molecule
+            host_address: 10.99.2.1
+            peer_address: 10.99.2.2
+            licensing_allowed: false
     host_vars:
       example-test:
         core_isolation_isolated_network_interfaces:
@@ -39,6 +54,7 @@ provisioner:
           - VRT_INTERFACE_PINNING__eth0=[1]
   playbooks:
     converge: ../../voraus/ipc_tools/playbooks/example.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: testinfra
   options:

--- a/molecule/shared/side_effect.yml
+++ b/molecule/shared/side_effect.yml
@@ -1,0 +1,37 @@
+---
+# Provisions the simulated remote sources for the CodeMeter firewall tests. A single VM has no
+# non-local source address, so both are simulated with a veth pair into a network namespace.
+#
+# This runs as a side effect and not during prepare, because network namespaces and veth pairs are
+# runtime state: scenarios that install a kernel or change the kernel cmdline reboot during
+# converge, which would wipe a harness created earlier.
+- name: Provision simulated remote sources for the firewall tests
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Install dependencies for the firewall probes
+      ansible.builtin.apt:
+        pkg:
+          - iproute2
+          - netcat-openbsd
+        state: present
+        update_cache: true
+      when: wibu_packages_firewall_probes | default([]) | length > 0
+
+    - name: Create the probe network namespaces and veth pairs
+      ansible.builtin.shell:
+        cmd: |
+          set -euo pipefail
+          ip netns list | grep -qw '{{ item.namespace }}' || ip netns add '{{ item.namespace }}'
+          ip link show '{{ item.interface }}' > /dev/null 2>&1 || \
+            ip link add '{{ item.interface }}' type veth peer name veth-peer netns '{{ item.namespace }}'
+          ip address replace '{{ item.host_address }}/24' dev '{{ item.interface }}'
+          ip link set '{{ item.interface }}' up
+          ip -netns '{{ item.namespace }}' address replace '{{ item.peer_address }}/24' dev veth-peer
+          ip -netns '{{ item.namespace }}' link set veth-peer up
+        executable: /bin/bash
+      changed_when: true
+      loop: '{{ wibu_packages_firewall_probes | default([]) }}'
+      loop_control:
+        label: '{{ item.namespace }}'

--- a/molecule/wibu_packages/molecule.yml
+++ b/molecule/wibu_packages/molecule.yml
@@ -23,28 +23,59 @@ platforms:
     networks:
       - name: 'public_network'
         type: 'dhcp'
+  - name: wibu-packages-no-firewall
+    box: cloud-image/debian-13
+    memory: 1024
+    cpus: 1
+    networks:
+      - name: 'public_network'
+        type: 'dhcp'
 provisioner:
   name: ansible
   inventory:
     group_vars:
       all:
         role_name: voraus.ipc_tools.wibu_packages
+        # Remote sources for the firewall tests, provisioned by `../shared/side_effect.yml`. The
+        # host side of the container pair matches the `br-*` interface pattern, which makes a
+        # docker daemon unnecessary.
+        wibu_packages_firewall_probes:
+          - namespace: cm-container
+            interface: br-molecule
+            host_address: 10.99.1.1
+            peer_address: 10.99.1.2
+            # Simulates a container, so it may reach the licensing port
+            licensing_allowed: true
+          - namespace: cm-external
+            interface: ext-molecule
+            host_address: 10.99.2.1
+            peer_address: 10.99.2.2
+            licensing_allowed: false
     host_vars:
       # Clean machine without the old repo/key
       wibu-packages-test:
         wibu_packages_provision_old_repo: false
+        wibu_packages_firewall: true
       # Machine pre-provisioned with the old wibu repo and GPG key
       wibu-packages-old-repo-present:
         wibu_packages_provision_old_repo: true
+        wibu_packages_firewall: true
+      # Machine on which the firewall is explicitly disabled
+      wibu-packages-no-firewall:
+        wibu_packages_provision_old_repo: false
+        wibu_packages_firewall: false
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml
+    side_effect: ../shared/side_effect.yml
 verifier:
   name: testinfra
   options:
     # https://github.com/pytest-dev/pytest-testinfra/issues/58#issuecomment-1839460327
     # pytest-ansible conflicts with --connection
     p: 'no:pytest-ansible'
+
+    sudo: true # reading the nftables ruleset and entering a network namespace require root
 
     # avoid loading global pyproject.toml options, so we don't
     # load the setting that says "disable testinfra"

--- a/molecule/wibu_packages/tests/test_wibu_packages.py
+++ b/molecule/wibu_packages/tests/test_wibu_packages.py
@@ -1,6 +1,32 @@
+from typing import Any
+
 import pytest
 from testinfra.host import Host
 from testinfra.modules.package import Package
+
+LICENSING_PORT = 22350
+WEBADMIN_PORT = 22352
+NFT_TABLE = "inet wibu_codemeter"
+NFT_CONFIG_PATH = "/etc/nftables.d/wibu-codemeter.nft"
+FIREWALL_SERVICE = "wibu-codemeter-firewall"
+FIREWALL_UNIT_PATH = f"/etc/systemd/system/{FIREWALL_SERVICE}.service"
+# The verifier runs the tests through sudo, `nft` is not in the connecting user's PATH though
+NFT = "/usr/sbin/nft"
+
+
+def firewall_enabled(host: Host) -> bool:
+    return bool(host.ansible.get_variables()["wibu_packages_firewall"])
+
+
+def firewall_probes(host: Host) -> list[dict[str, Any]]:
+    return list(host.ansible.get_variables()["wibu_packages_firewall_probes"])
+
+
+def probe_can_connect(host: Host, probe: dict[str, Any], port: int) -> bool:
+    # Dropped packets make the connection attempt time out instead of being refused, so netcat
+    # needs a timeout to not block forever.
+    result = host.run("ip netns exec %s nc -z -w 2 %s %s", probe["namespace"], probe["host_address"], str(port))
+    return result.rc == 0
 
 
 @pytest.mark.parametrize(
@@ -25,3 +51,63 @@ def test_old_repo_and_key_removed(host: Host) -> None:
     # machines that were previously provisioned with them.
     assert not host.file("/usr/share/keyrings/wibu-package-maintainers.gpg").exists
     assert not host.file("/etc/apt/sources.list.d/voraus-wibu.list").exists
+
+
+def test_firewall_rules_loaded(host: Host) -> None:
+    ruleset = host.run(f"{NFT} list table {NFT_TABLE}")
+
+    if not firewall_enabled(host):
+        assert not host.file(NFT_CONFIG_PATH).exists
+        assert not host.file(FIREWALL_UNIT_PATH).exists
+        # Either nftables was never installed or the table is gone, both are acceptable
+        assert ruleset.rc != 0, f"The '{NFT_TABLE}' table is still loaded although the firewall is disabled"
+        return
+
+    assert host.file(NFT_CONFIG_PATH).exists
+    assert host.service(FIREWALL_SERVICE).is_enabled
+    assert host.service(FIREWALL_SERVICE).is_running
+    assert ruleset.rc == 0, f"The '{NFT_TABLE}' table is not loaded: {ruleset.stderr}"
+
+    expected_rules = [
+        # The licensing port is reachable from the host itself and from container bridges
+        f'iifname "lo" tcp dport {LICENSING_PORT} accept',
+        f'iifname "lo" udp dport {LICENSING_PORT} accept',
+        f'iifname "docker0" tcp dport {LICENSING_PORT} accept',
+        f'iifname "br-*" tcp dport {LICENSING_PORT} accept',
+        f"tcp dport {LICENSING_PORT} drop",
+        f"udp dport {LICENSING_PORT} drop",
+        # WebAdmin is restricted to the host itself, containers included
+        f'iifname "lo" tcp dport {WEBADMIN_PORT} accept',
+        f"tcp dport {WEBADMIN_PORT} drop",
+    ]
+    for expected_rule in expected_rules:
+        assert expected_rule in ruleset.stdout, f"Missing rule '{expected_rule}' in:\n{ruleset.stdout}"
+
+    assert f'iifname "docker0" tcp dport {WEBADMIN_PORT} accept' not in ruleset.stdout
+
+
+def test_licensing_port_reachable_from_localhost(host: Host) -> None:
+    assert host.run("nc -z -w 2 127.0.0.1 %s", str(LICENSING_PORT)).rc == 0
+
+
+def test_licensing_port_access(host: Host) -> None:
+    for probe in firewall_probes(host):
+        # Without the firewall every source may connect
+        expected = probe["licensing_allowed"] or not firewall_enabled(host)
+        connected = probe_can_connect(host, probe, LICENSING_PORT)
+        assert connected == expected, (
+            f"{probe['namespace']} (via {probe['interface']}) "
+            f"{'could not' if expected else 'could'} reach port {LICENSING_PORT}"
+        )
+
+
+def test_webadmin_port_not_reachable_from_remote_sources(host: Host) -> None:
+    # Only meaningful while the firewall is enabled: without it the result depends on whether the
+    # installed CodeMeter variant serves WebAdmin at all.
+    if not firewall_enabled(host):
+        pytest.skip("The firewall is disabled on this host")
+
+    for probe in firewall_probes(host):
+        assert not probe_can_connect(
+            host, probe, WEBADMIN_PORT
+        ), f"{probe['namespace']} (via {probe['interface']}) could reach port {WEBADMIN_PORT}"

--- a/voraus/ipc_tools/roles/wibu_packages/README.md
+++ b/voraus/ipc_tools/roles/wibu_packages/README.md
@@ -7,11 +7,54 @@ Install WiBu packages on the system that are required for handling licensed comp
 
 ## Requirements
 
-None.
+None. The `nftables` package is installed by the role if the firewall is enabled.
 
 ## Role Variables
 
 The `defaults/main.yml` file always provides a complete list of the variables.
+
+## Firewall
+
+With `wibu_packages_firewall` enabled (the default), access to the CodeMeter ports is restricted to
+the host itself and to container networks:
+
+| Port                                    | Reachable from                                                     |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| 22350/tcp+udp (licensing and discovery) | the host itself, `docker0` and user defined `br-*` docker networks |
+| 22352/tcp (WebAdmin)                    | the host itself                                                    |
+
+The WebAdmin interface is therefore no longer reachable from other machines. Use an SSH tunnel to
+access it: `ssh -L 22352:127.0.0.1:22352 <ipc>`, then open <http://127.0.0.1:22352>.
+
+Connections that the host makes to its own LAN address are routed through the loopback interface,
+so local clients work regardless of whether they use `127.0.0.1` or the host address.
+
+The rules live in their own nftables table (`inet wibu_codemeter`). Setting `wibu_packages_firewall`
+to `false` removes the table, the rules and the unit again.
+
+`wibu_packages_cm_bind_address` intentionally stays at `0.0.0.0`: binding CodeMeter to the loopback
+interface would also cut off containers, because their traffic arrives on the bridge address.
+
+### Interaction with other rulesets
+
+The table is loaded by the `wibu-codemeter-firewall.service` unit, **not** by `nftables.service`:
+`/etc/nftables.d/` is not a Debian convention, the directory belongs to this role. Loading the file
+through the distribution's `/etc/nftables.conf` was rejected on purpose, because that file starts
+with `flush ruleset` and would therefore drop the rules of Docker, Kubernetes and everyone else on
+every reload.
+
+Because the rules live in their own table, no other ruleset is touched and no other ruleset can
+re-open the ports: a `drop` is final, while an `accept` only ends the evaluation of its own chain.
+That also holds the other way round, which matters on hardened hosts:
+
+- A `policy drop` in another table blocks the CodeMeter ports regardless of the rules of this role.
+  On such a host, 22350 needs to be allowed in that ruleset as well, otherwise the license server
+  stays unreachable.
+- Anything that flushes the whole ruleset removes this table too, `nft flush ruleset` as well as
+  `nftables.service`, which flushes through its config and on stop. The unit is ordered after that
+  service so that a boot is safe, but a flush at runtime leaves the ports open until the role runs
+  again or `systemctl reload wibu-codemeter-firewall` is called. Note that such a flush also drops
+  the rules of Docker and Kubernetes, so it is not something to expect on a running IPC.
 
 ## Dependencies
 
@@ -33,6 +76,28 @@ None.
     wibu_packages_install:
       codemeter-lite: 8.20.6539.500
       axprotector: 11.70.7131.502
+  roles:
+    - voraus.ipc_tools.wibu_packages
+```
+
+```yaml
+- name: Install WiBu packages without restricting access to the CodeMeter ports
+  hosts: all
+  vars:
+    wibu_packages_firewall: false
+  roles:
+    - voraus.ipc_tools.wibu_packages
+```
+
+```yaml
+- name: Allow an additional network to access the CodeMeter license server
+  hosts: all
+  vars:
+    wibu_packages_firewall_licensing_interfaces:
+      - lo
+      - docker0
+      - 'br-*'
+      - eno1
   roles:
     - voraus.ipc_tools.wibu_packages
 ```

--- a/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
@@ -9,3 +9,27 @@ wibu_packages_cm_service_name: codemeter.service
 wibu_packages_cm_config_path: /etc/wibu/CodeMeter/Server.ini
 wibu_packages_cm_is_network_server: true
 wibu_packages_cm_bind_address: '0.0.0.0'
+
+# The CodeMeter licensing port (TCP for the license protocol, UDP for network server discovery)
+wibu_packages_cm_port: 22350
+# The CodeMeter WebAdmin port
+wibu_packages_cm_webadmin_port: 22352
+
+# Restrict access to the CodeMeter ports to the host itself and to container networks using a
+# dedicated nftables table. Setting this to `false` removes the rules again.
+wibu_packages_firewall: true
+
+# Interfaces that are allowed to reach the licensing port. Wildcards are matched by nftables,
+# `br-*` covers user defined docker networks.
+wibu_packages_firewall_licensing_interfaces:
+  - lo
+  - docker0
+  - 'br-*'
+
+# Interfaces that are allowed to reach the WebAdmin port
+wibu_packages_firewall_webadmin_interfaces:
+  - lo
+
+wibu_packages_firewall_table_name: wibu_codemeter
+wibu_packages_firewall_config_path: /etc/nftables.d/wibu-codemeter.nft
+wibu_packages_firewall_service_name: wibu-codemeter-firewall.service

--- a/voraus/ipc_tools/roles/wibu_packages/handlers/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/handlers/main.yml
@@ -9,3 +9,14 @@
     name: '{{ wibu_packages_cm_service_name }}'
     state: restarted
     enabled: true
+
+# `ExecReload` applies the whole file in a single nftables transaction, so the ports are never
+# unprotected in between
+- name: Reload CodeMeter Firewall Rules
+  ansible.builtin.systemd_service:
+    name: '{{ wibu_packages_firewall_service_name }}'
+    state: reloaded
+
+- name: Reload Systemd Daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/configure_firewall.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/configure_firewall.yml
@@ -1,0 +1,68 @@
+---
+# The rules are loaded by an own systemd unit instead of being included into Debian's
+# /etc/nftables.conf, because that file starts with `flush ruleset`: reloading it would drop
+# Docker's rules as well and break container networking until the docker daemon is restarted.
+- name: Restrict access to the CodeMeter ports
+  when: wibu_packages_firewall | bool
+  block:
+    - name: Install nftables
+      ansible.builtin.apt:
+        name: nftables
+        state: present
+        update_cache: true
+
+    - name: Create the nftables configuration directory
+      ansible.builtin.file:
+        path: '{{ wibu_packages_firewall_config_path | dirname }}'
+        state: directory
+        mode: '0755'
+
+    - name: Configure the CodeMeter firewall rules
+      ansible.builtin.template:
+        src: wibu-codemeter.nft.j2
+        dest: '{{ wibu_packages_firewall_config_path }}'
+        mode: '0644'
+        validate: /usr/sbin/nft -c -f %s
+      notify:
+        - Reload CodeMeter Firewall Rules
+
+    - name: Install the CodeMeter firewall systemd service
+      ansible.builtin.template:
+        src: wibu-codemeter-firewall.service.j2
+        dest: '/etc/systemd/system/{{ wibu_packages_firewall_service_name }}'
+        mode: '0644'
+      notify:
+        - Reload CodeMeter Firewall Rules
+
+    - name: Enable and start the CodeMeter firewall service
+      ansible.builtin.systemd_service:
+        name: '{{ wibu_packages_firewall_service_name }}'
+        state: started
+        enabled: true
+        daemon_reload: true
+
+- name: Remove the CodeMeter port restrictions
+  when: not wibu_packages_firewall | bool
+  block:
+    - name: Check whether the CodeMeter firewall service is installed
+      ansible.builtin.stat:
+        path: '/etc/systemd/system/{{ wibu_packages_firewall_service_name }}'
+      register: wibu_packages_firewall_unit
+
+    # Stopping the service removes the nftables table through its `ExecStop`
+    - name: Stop and disable the CodeMeter firewall service
+      ansible.builtin.systemd_service:
+        name: '{{ wibu_packages_firewall_service_name }}'
+        state: stopped
+        enabled: false
+      when: wibu_packages_firewall_unit.stat.exists
+
+    - name: Remove the CodeMeter firewall rules and systemd service
+      ansible.builtin.file:
+        path: '{{ item }}'
+        state: absent
+      loop:
+        - '/etc/systemd/system/{{ wibu_packages_firewall_service_name }}'
+        - '{{ wibu_packages_firewall_config_path }}'
+      notify:
+        - Reload Systemd Daemon

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/install_codemeter.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/install_codemeter.yml
@@ -36,3 +36,6 @@
       value: '{{ wibu_packages_cm_bind_address }}'
   notify:
     - Enable and Start CodeMeter Systemd Service
+
+- name: Configure the CodeMeter firewall
+  ansible.builtin.include_tasks: configure_firewall.yml

--- a/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter-firewall.service.j2
+++ b/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter-firewall.service.j2
@@ -1,0 +1,22 @@
+# {{ ansible_managed }}
+[Unit]
+Description=nftables rules restricting WiBu CodeMeter access to local and container networks
+Documentation=man:nft(8)
+Wants=network-pre.target
+Before=network-pre.target shutdown.target
+# Debian's /etc/nftables.conf starts with `flush ruleset`, so this table has to be loaded after
+# nftables.service to survive a boot on hosts on which that service is enabled
+After=nftables.service
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+StandardInput=null
+ExecStart=/usr/sbin/nft -f {{ wibu_packages_firewall_config_path }}
+ExecReload=/usr/sbin/nft -f {{ wibu_packages_firewall_config_path }}
+ExecStop=/usr/sbin/nft destroy table inet {{ wibu_packages_firewall_table_name }}
+
+[Install]
+WantedBy=sysinit.target

--- a/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter.nft.j2
+++ b/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter.nft.j2
@@ -1,0 +1,33 @@
+#!/usr/sbin/nft -f
+#
+# {{ ansible_managed }}
+#
+# Restricts access to the WiBu CodeMeter ports to the host itself and to container networks.
+#
+# These rules live in their own table on purpose: a `drop` in any table is final, while an
+# `accept` only ends the evaluation of *this* chain. Docker's and any other ruleset therefore
+# stay untouched, and their `accept` rules cannot re-open the ports.
+
+# Replace a previously loaded revision, so that this file can be re-applied as a whole
+destroy table inet {{ wibu_packages_firewall_table_name }}
+
+table inet {{ wibu_packages_firewall_table_name }} {
+  chain input {
+    type filter hook input priority filter; policy accept;
+
+    # Licensing port. Wildcards only match in single value comparisons, not in sets,
+    # which is why every interface gets its own rule.
+{% for interface in wibu_packages_firewall_licensing_interfaces %}
+    iifname "{{ interface }}" tcp dport {{ wibu_packages_cm_port }} accept
+    iifname "{{ interface }}" udp dport {{ wibu_packages_cm_port }} accept
+{% endfor %}
+    tcp dport {{ wibu_packages_cm_port }} drop
+    udp dport {{ wibu_packages_cm_port }} drop
+
+    # WebAdmin port
+{% for interface in wibu_packages_firewall_webadmin_interfaces %}
+    iifname "{{ interface }}" tcp dport {{ wibu_packages_cm_webadmin_port }} accept
+{% endfor %}
+    tcp dport {{ wibu_packages_cm_webadmin_port }} drop
+  }
+}


### PR DESCRIPTION
CodeMeter listens on `0.0.0.0`, so both the licensing port 22350 and the
WebAdmin port 22352 were reachable from the entire network. Narrowing
`wibu_packages_cm_bind_address` is not an option, because containers reach the
license server through the bridge address and would lose access as well. The
restriction is therefore enforced with a packet filter.

The new `wibu_packages_firewall` flag, enabled by default, renders
`/etc/nftables.d/wibu-codemeter.nft` and loads it through an own
`wibu-codemeter-firewall.service` unit. 22350/tcp+udp stays reachable from the
host itself and from container bridges (`docker0` and user defined `br-*`
networks), 22352/tcp only from the host itself. UDP matters as well, because
CodeMeter uses it for network server discovery. WebAdmin is now reached through
an SSH tunnel, which `README.md` documents. Setting the flag to `false` removes
the table, the rules and the unit again.

The rules live in their own `inet wibu_codemeter` table: a `drop` in any table
is final, while an `accept` only ends the evaluation of its own chain. Docker's
ruleset stays untouched and its rules cannot re-open the ports. Loading the file
through an own unit instead of including it into `/etc/nftables.conf` avoids
that file's `flush ruleset`, which would drop Docker's rules on every reload and
break container networking until the daemon is restarted. Interface wildcards
only match in single value comparisons and not in sets, which is why every
interface gets its own rule.

The `wibu_packages` molecule scenario gains a `wibu-packages-no-firewall`
platform for the disabled case. Since a single VM has no non-local source
address, `prepare.yml` sets up two veth pairs into network namespaces, one of
them named `br-molecule` so that it matches the container pattern without a
docker daemon being involved.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
