### PR TITLE
fix(wibu_packages): Update `codemeter-lite` to 9.10.8166.500

### DIFF
--- a/molecule/wibu_packages/tests/test_wibu_packages.py
+++ b/molecule/wibu_packages/tests/test_wibu_packages.py
@@ -5,7 +5,7 @@ from testinfra.modules.package import Package
 
 @pytest.mark.parametrize(
     ("package_name", "package_version"),
-    [("codemeter-lite", "9.0.8031.500"), ("axprotector", "11.80.8031.500")],
+    [("codemeter-lite", "9.10.8166.500"), ("axprotector", "11.80.8031.500")],
 )
 def test_packages_installed(package_name: str, package_version: str, host: Host) -> None:
     package: Package = host.package(package_name)

--- a/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 wibu_packages_install:
-  codemeter-lite: 9.0.8031.500
+  codemeter-lite: 9.10.8166.500
   axprotector: 11.80.8031.500
 
 wibu_packages_allow_downgrades: true


### PR DESCRIPTION
Bump `codemeter-lite` from `9.0.8031.500` to `9.10.8166.500` in
`voraus/ipc_tools/roles/wibu_packages/defaults/main.yml` and align the
expected version in `molecule/wibu_packages/tests/test_wibu_packages.py`.

CodeMeter Runtime 9.10 is the first 9.x release fixing the issues from
these Wibu-Systems security advisories (both published 2026-08-04,
document version 1.0):

- WIBU-103401 "Vulnerabilities in CodeMeter Runtime If Configured as
  Server" (CVSSv3.1 7.5 to 8.6, highest severity High):
  - Improper Access Control in Local-Only Configuration Commands
    (CWE-284, 8.6) - remote read/write of `Server.ini`, including the
    WebAdmin credential hash
  - Format String Vulnerability in Logger (CWE-134, 8.2)
  - Improper Authentication of Session Handles (CWE-639, 7.7)
  - Missing Sanity Checks for Buffer Lengths (CWE-130, 7.5)
- WIBU-103081 "Local Privilege Escalation in CodeMeter Runtime on
  Windows" (CWE-59, CVSSv3.1 7.8, High). Windows-only, so it does not
  affect our Linux IPCs.

The WIBU-103401 vulnerabilities require CodeMeter to run as a network
server. That is not Wibu's default, but it *is* ours: this role sets
`IsNetworkServer=1` via `wibu_packages_cm_is_network_server` and binds to
`0.0.0.0` via `wibu_packages_cm_bind_address`, so every host provisioned
with the role defaults is affected and reachable on all interfaces.
Wibu's mitigation (`cmu --disable-network-server`) is not an option for
us because the license server is exposed intentionally, which makes this
version bump the only remediation.

Wibu lists the CVE IDs for all five vulnerabilities as "Pending (waiting
for MITRE)"; they will be added to the advisories once assigned.

Advisories: https://www.wibu.com/de/support/security-advisories.html
(the full documents require a Wibu login until 2026-08-25)
