### PR TITLE
fix(wibu_packages): Replace `destroy table` with a portable nftables idiom

### DIFF
--- a/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter-firewall.service.j2
+++ b/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter-firewall.service.j2
@@ -16,7 +16,10 @@ RemainAfterExit=yes
 StandardInput=null
 ExecStart=/usr/sbin/nft -f {{ wibu_packages_firewall_config_path }}
 ExecReload=/usr/sbin/nft -f {{ wibu_packages_firewall_config_path }}
-ExecStop=/usr/sbin/nft destroy table inet {{ wibu_packages_firewall_table_name }}
+# Declaring the table first makes the removal succeed even if the rules were never loaded, without
+# relying on `destroy table`, which requires nftables >= 1.0.6 and a kernel >= 6.3
+ExecStop=/usr/sbin/nft add table inet {{ wibu_packages_firewall_table_name }}
+ExecStop=/usr/sbin/nft delete table inet {{ wibu_packages_firewall_table_name }}
 
 [Install]
 WantedBy=sysinit.target

--- a/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter.nft.j2
+++ b/voraus/ipc_tools/roles/wibu_packages/templates/wibu-codemeter.nft.j2
@@ -8,8 +8,12 @@
 # `accept` only ends the evaluation of *this* chain. Docker's and any other ruleset therefore
 # stay untouched, and their `accept` rules cannot re-open the ports.
 
-# Replace a previously loaded revision, so that this file can be re-applied as a whole
-destroy table inet {{ wibu_packages_firewall_table_name }}
+# Replace a previously loaded revision, so that this file can be re-applied as a whole. Declaring
+# the table before deleting it is a no-op if it already exists and creates it otherwise, so the
+# `delete` also succeeds on a host that has never loaded these rules. `destroy table` would express
+# the same intent in one statement, but it requires nftables >= 1.0.6 and a kernel >= 6.3.
+table inet {{ wibu_packages_firewall_table_name }} {}
+delete table inet {{ wibu_packages_firewall_table_name }}
 
 table inet {{ wibu_packages_firewall_table_name }} {
   chain input {


### PR DESCRIPTION
`destroy table` needs nftables >= 1.0.6 in userspace and a kernel >= 6.3. On a
host with an older `nft` the `validate` step of the `Configure the CodeMeter
firewall rules` task fails with a syntax error, so the whole play aborts for that
host. Hosts with a new enough `nft` but an older kernel pass validation and would
instead fail later, when the ruleset is actually loaded.

Declare the table before deleting it: `table inet <name> {}` is a no-op when the
table already exists and creates it otherwise, so the following `delete table` is
always valid. This construct has been available since nftables 0.9.x.

`wibu-codemeter.nft.j2` keeps its add-delete-add sequence inside the single
transaction that `nft -f` opens, so the ports are never briefly unprotected while
the rules are replaced. In `wibu-codemeter-firewall.service.j2` the same pattern
is expressed as two sequential `ExecStop` commands rather than a `-` prefixed
one, so a genuine `delete` failure still surfaces as a failed stop.

Verified by rendering both templates with the role defaults and, in a throwaway
network namespace, running `nft -c -f` on the result, applying it twice in a row
and exercising the `ExecStop` pair against both an existing and an absent table.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
