### PR TITLE
feat(wibu_packages): Use the deb822 apt sources format everywhere

### DIFF
--- a/molecule/wibu_packages/prepare.yml
+++ b/molecule/wibu_packages/prepare.yml
@@ -2,34 +2,79 @@
 - name: Import shared prepare playbook
   ansible.builtin.import_playbook: ../shared/prepare.yml
 
-- name: Provision old wibu apt repo and GPG key
+# Reproduces the state of a host that was provisioned by an earlier revision of this role, or by
+# following the pre-Artifactory instructions of https://github.com/vorausrobotik/wibu-packages, so
+# that the migration to the deb822 source and the repository scoped keyring is covered by the tests.
+- name: Provision legacy wibu apt sources and GPG keys
   hosts: all
   become: true
 
   tasks:
-    - name: Install dependencies for old repo provisioning
-      ansible.builtin.apt:
-        pkg:
-          - gnupg2
-          - curl
-        state: present
-        update_cache: true
+    - name: Provision the legacy apt sources and GPG keys
       when: wibu_packages_provision_old_repo | default(false)
+      block:
+        - name: Install dependencies for the legacy repo provisioning
+          ansible.builtin.apt:
+            pkg:
+              - gnupg2
+              - curl
+            state: present
+            update_cache: true
 
-    - name: Download and dearmor old wibu GPG key
-      ansible.builtin.shell: |
-        set -o pipefail
-        curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/wibu-packages-maintainers.gpg | \
-        gpg --dearmor -o /usr/share/keyrings/wibu-package-maintainers.gpg
-      args:
-        executable: /bin/bash
-        creates: /usr/share/keyrings/wibu-package-maintainers.gpg
-      when: wibu_packages_provision_old_repo | default(false)
+        - name: Download and dearmor the retired wibu maintainers key
+          ansible.builtin.shell: |
+            set -o pipefail
+            curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/wibu-packages-maintainers.gpg | \
+            gpg --dearmor -o {{ item }}
+          args:
+            executable: /bin/bash
+            creates: '{{ item }}'
+          loop:
+            # Where earlier revisions of this role placed the key
+            - /usr/share/keyrings/wibu-package-maintainers.gpg
+            # Where the upstream README told users to place it
+            - /etc/apt/trusted.gpg.d/wibu-packages-maintainers.gpg
 
-    - name: Add old wibu apt repo
-      ansible.builtin.apt_repository:
-        repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
-        filename: voraus-wibu
-        state: present
-        update_cache: true
-      when: wibu_packages_provision_old_repo | default(false)
+        - name: Add the retired wibu apt repo
+          ansible.builtin.apt_repository:
+            repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
+            filename: voraus-wibu
+            state: present
+            update_cache: false
+
+        - name: Download and dearmor the Artifactory key as a globally trusted one
+          ansible.builtin.shell: |
+            set -o pipefail
+            curl -s --compressed https://voraus.jfrog.io/ui/api/v1/ui/security/keyPairs/voraus-gpg/public | \
+            gpg --dearmor -o /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+          args:
+            executable: /bin/bash
+            creates: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+
+        # Both Artifactory sources are seeded, because a host can carry both: the one-line source
+        # was written while it still ran Debian 12, the deb822 one after it had been upgraded to
+        # Debian 13, and the role never removed the former. They name the same key, so apt reads
+        # them without a `Signed-By` conflict.
+        - name: Add the one-line Artifactory apt source
+          ansible.builtin.apt_repository:
+            repo: 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/vorausrobotik.gpg] https://voraus.jfrog.io/artifactory/debian stable main'
+            filename: voraus
+            state: present
+            update_cache: false
+
+        - name: Add the deb822 Artifactory apt source written by the previous role revision
+          ansible.builtin.copy:
+            dest: /etc/apt/sources.list.d/voraus.sources
+            mode: '0644'
+            content: |
+              X-Repolib-Name: voraus
+              Types: deb
+              URIs: https://voraus.jfrog.io/artifactory/debian
+              Suites: stable
+              Components: main
+              Architectures: amd64
+              Signed-By: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+
+        - name: Update the apt cache with the legacy sources in place
+          ansible.builtin.apt:
+            update_cache: true

--- a/molecule/wibu_packages/tests/test_wibu_packages.py
+++ b/molecule/wibu_packages/tests/test_wibu_packages.py
@@ -13,6 +13,20 @@ FIREWALL_UNIT_PATH = f"/etc/systemd/system/{FIREWALL_SERVICE}.service"
 # The verifier runs the tests through sudo, `nft` is not in the connecting user's PATH though
 NFT = "/usr/sbin/nft"
 
+APT_SOURCE_PATH = "/etc/apt/sources.list.d/vorausrobotik.sources"
+# The Artifactory key is served ASCII armored, which `deb822_repository` stores as `.asc`
+APT_KEYRING_PATH = "/etc/apt/keyrings/vorausrobotik.asc"
+# Sources and keys written by earlier revisions of this role or by the pre-Artifactory upstream
+# instructions. All of them must be gone once the role has run.
+LEGACY_APT_PATHS = [
+    "/etc/apt/sources.list.d/voraus-wibu.list",
+    "/usr/share/keyrings/wibu-package-maintainers.gpg",
+    "/etc/apt/trusted.gpg.d/wibu-packages-maintainers.gpg",
+    "/etc/apt/sources.list.d/voraus.list",
+    "/etc/apt/sources.list.d/voraus.sources",
+    "/etc/apt/trusted.gpg.d/vorausrobotik.gpg",
+]
+
 
 def firewall_enabled(host: Host) -> bool:
     return bool(host.ansible.get_variables()["wibu_packages_firewall"])
@@ -46,11 +60,28 @@ def test_codemeter_listens(host: Host) -> None:
     assert host.socket("tcp://22350").is_listening
 
 
-def test_old_repo_and_key_removed(host: Host) -> None:
-    # The role must clean up the rotated-out wibu repo and GPG key, including on
-    # machines that were previously provisioned with them.
-    assert not host.file("/usr/share/keyrings/wibu-package-maintainers.gpg").exists
-    assert not host.file("/etc/apt/sources.list.d/voraus-wibu.list").exists
+@pytest.mark.parametrize("path", LEGACY_APT_PATHS)
+def test_legacy_sources_and_keys_removed(path: str, host: Host) -> None:
+    # The role must clean up the rotated-out repositories and GPG keys, including on machines that
+    # were previously provisioned with them.
+    assert not host.file(path).exists, f"'{path}' is still present"
+
+
+def test_deb822_source_configured(host: Host) -> None:
+    source = host.file(APT_SOURCE_PATH)
+    assert source.exists, f"'{APT_SOURCE_PATH}' was not written"
+
+    content = source.content_string
+    assert "Types: deb" in content
+    assert "URIs: https://voraus.jfrog.io/artifactory/debian" in content
+    assert f"Signed-By: {APT_KEYRING_PATH}" in content
+
+
+def test_signing_key_is_repository_scoped(host: Host) -> None:
+    # The key must live in a keyring referenced by `Signed-By`, not in `/etc/apt/trusted.gpg.d`,
+    # from where apt would trust it for every configured repository.
+    assert host.file(APT_KEYRING_PATH).exists, f"'{APT_KEYRING_PATH}' is missing"
+    assert host.run("apt-get update").rc == 0
 
 
 def test_firewall_rules_loaded(host: Host) -> None:

--- a/voraus/ipc_tools/roles/wibu_packages/meta/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/meta/main.yml
@@ -9,6 +9,14 @@ galaxy_info:
 
   min_ansible_version: '2.1'
 
+  # The apt source is written in the deb822 format and references an ASCII armored keyring, which
+  # requires apt >= 1.4. Both are well covered by the releases listed here.
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+        - trixie
+
   galaxy_tags: []
 
 dependencies: []

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/add_voraus_repo.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/add_voraus_repo.yml
@@ -1,32 +1,23 @@
 ---
-# Debian 13+ deprecates one-line .list sources in favor of the deb822 .sources
-# format, so use deb822_repository there and apt_repository on older releases.
-- name: Determine whether to use the deb822 sources format
-  ansible.builtin.set_fact:
-    wibu_packages_use_deb822: "{{ ansible_distribution == 'Debian' and ansible_distribution_major_version is version('13', '>=') }}"
-
-- name: Add voraus packages apt repo (deb822 format)
+# The deb822 `.sources` format is used on every distribution: it is the format documented by
+# https://github.com/vorausrobotik/wibu-packages, Debian 13 deprecates the one-line `.list` format,
+# and every release this collection supports (Debian 12 and later, apt 2.6) is far above the apt 1.4
+# that the ASCII armored keyring below requires. The source is named after that documentation, so a
+# host set up by hand ends up with the very same `/etc/apt/sources.list.d/vorausrobotik.sources`
+# instead of a second, competing source file.
+#
+# `signed_by` is passed as a URL, which makes the module fetch the Artifactory signing key into
+# `/etc/apt/keyrings` and reference it from the source. A keyring referenced through `Signed-By` is
+# only trusted for this repository, whereas a key in `/etc/apt/trusted.gpg.d` would be trusted for
+# every repository configured on the host.
+- name: Add voraus packages apt repo
   ansible.builtin.deb822_repository:
-    name: voraus
+    name: vorausrobotik
     types: deb
     uris: https://voraus.jfrog.io/artifactory/debian
     suites: stable
     components: main
     architectures: amd64
-    signed_by: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+    signed_by: https://voraus.jfrog.io/ui/api/v1/ui/security/keyPairs/voraus-gpg/public
     state: present
-  when: wibu_packages_use_deb822
-  register: wibu_packages_deb822_repo
-
-- name: Update apt cache after adding deb822 repo # noqa: no-handler
-  ansible.builtin.apt:
-    update_cache: true
-  when: wibu_packages_deb822_repo is changed
-
-- name: Add voraus packages apt repo (one-line format)
-  ansible.builtin.apt_repository:
-    repo: 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/vorausrobotik.gpg] https://voraus.jfrog.io/artifactory/debian stable main'
-    filename: voraus
-    state: present
-    update_cache: true
-  when: not wibu_packages_use_deb822
+  register: wibu_packages_repo

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/cleanup_old_repo.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/cleanup_old_repo.yml
@@ -1,12 +1,21 @@
 ---
-- name: Remove old wibu apt repo
-  ansible.builtin.apt_repository:
-    repo: 'deb [arch=amd64 signed-by=/usr/share/keyrings/wibu-package-maintainers.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./'
-    filename: voraus-wibu
-    state: absent
-    update_cache: true
-
-- name: Remove old wibu GPG key
+# Sources and signing keys that earlier revisions of this role, or the pre-Artifactory instructions
+# of https://github.com/vorausrobotik/wibu-packages, left behind.
+- name: Remove legacy voraus apt sources and signing keys
   ansible.builtin.file:
-    path: /usr/share/keyrings/wibu-package-maintainers.gpg
+    path: '{{ item }}'
     state: absent
+  loop:
+    # The retired wibu-packages.vorausrobotik.com repository and its maintainers key. This role
+    # placed that key in `/usr/share/keyrings`, while the upstream README placed it in
+    # `/etc/apt/trusted.gpg.d`, from where apt trusts it for every repository.
+    - /etc/apt/sources.list.d/voraus-wibu.list
+    - /usr/share/keyrings/wibu-package-maintainers.gpg
+    - /etc/apt/trusted.gpg.d/wibu-packages-maintainers.gpg
+    # Artifactory sources written before this role used deb822 everywhere, and the Artifactory key
+    # it installed as a globally trusted one. Both are superseded by `vorausrobotik.sources` and the
+    # repository scoped keyring it references.
+    - /etc/apt/sources.list.d/voraus.list
+    - /etc/apt/sources.list.d/voraus.sources
+    - /etc/apt/trusted.gpg.d/vorausrobotik.gpg
+  register: wibu_packages_legacy_cleanup

--- a/voraus/ipc_tools/roles/wibu_packages/tasks/main.yml
+++ b/voraus/ipc_tools/roles/wibu_packages/tasks/main.yml
@@ -1,26 +1,29 @@
 ---
+# The cleanup runs first, before anything touches apt: when two source entries describe the same
+# repository with a different `Signed-By`, apt refuses to read its source list as a whole and every
+# apt operation fails. A host that ended up in that state - for example because an older revision of
+# this role ran over it again and re-added its one-line source - can only be repaired by removing
+# the offending files, which this task does through `ansible.builtin.file` alone.
+- name: Clean up legacy wibu apt sources and GPG keys
+  ansible.builtin.include_tasks: cleanup_old_repo.yml
+
 - name: Install apt dependencies
   ansible.builtin.apt:
     update_cache: true
     pkg:
-      - gnupg2
-      - curl
+      # Required by `ansible.builtin.deb822_repository`
+      - python3-debian
     state: present
-
-- name: Clean up old wibu apt repo and GPG key
-  ansible.builtin.include_tasks: cleanup_old_repo.yml
-
-- name: Download and dearmor voraus GPG key
-  ansible.builtin.shell: |
-    set -o pipefail
-    curl -s --compressed https://voraus.jfrog.io/ui/api/v1/ui/security/keyPairs/voraus-gpg/public | \
-    gpg --dearmor -o /etc/apt/trusted.gpg.d/vorausrobotik.gpg
-  args:
-    executable: /bin/bash
-    creates: /etc/apt/trusted.gpg.d/vorausrobotik.gpg
 
 - name: Add voraus packages apt repo
   ansible.builtin.include_tasks: add_voraus_repo.yml
+
+# The apt cache is refreshed here rather than through a handler, because the packages are installed
+# within this role and would otherwise be resolved against a stale cache.
+- name: Update apt cache after adding the apt source # noqa: no-handler
+  ansible.builtin.apt:
+    update_cache: true
+  when: wibu_packages_repo is changed
 
 - name: Include package specific tasks
   ansible.builtin.include_tasks: 'install_{{ package_mapping[item.key] }}.yml'


### PR DESCRIPTION
## Why

The role picked its apt source format by distribution: `deb822_repository` on Debian 13 and up,
`apt_repository` below. That gate was never necessary — `apt` reads the deb822 `.sources` format
since 1.1 (Debian 9) — and it left two code paths to keep in sync for no gain.

Two smaller defects came to light while removing it:

- The signing key was installed into `/etc/apt/trusted.gpg.d`, from where `apt` trusts it for
  **every** repository on the host, not just ours.
- `cleanup_old_repo.yml` only removed the key path this role itself had written
  (`/usr/share/keyrings/wibu-package-maintainers.gpg`). Hosts set up by hand from the
  [upstream README](https://github.com/vorausrobotik/wibu-packages) carry it at
  `/etc/apt/trusted.gpg.d/wibu-packages-maintainers.gpg` and kept trusting the rotated-out
  maintainers key indefinitely.

## What changed

**One unconditional deb822 source.** The `wibu_packages_use_deb822` fact and the `apt_repository`
branch are gone. The source is named `vorausrobotik`, matching the file name the upstream README
documents, so a host set up by hand converges on the same file instead of gaining a second,
competing source.

**The key is scoped to this repository.** `signed_by` is passed as the Artifactory key URL;
`deb822_repository` fetches it into `/etc/apt/keyrings` and references it via `Signed-By`. This
replaces the `curl | gpg --dearmor` shell task, so `gnupg2` and `curl` give way to `python3-debian`,
which the module requires.

**The cleanup covers every legacy path** — both maintainers key locations, the retired
`voraus-wibu.list`, and the `voraus.list` / `voraus.sources` / `trusted.gpg.d` artifacts of the
previous role revision. It removes files instead of matching a repository line, so it no longer
depends on reproducing that line byte for byte.

**It runs before anything else touches `apt`.** Once two entries describe the same repository with a
different `Signed-By`, `apt` refuses to read its source list as a whole and every `apt` call fails.
Such a host has to be repaired with plain file removals before the first `update_cache` — ordering
the cleanup later would make the role fail on exactly the hosts it is meant to fix.

**Supported platforms are declared** in `meta/main.yml`. The armored keyring needs `apt` >= 1.4,
which rules out anything older than Debian 12.

## Verification

Run against a `debian:12` container with the role's actual task files:

| Scenario | Result |
| --- | --- |
| Full legacy layout → role | all six legacy paths removed, `vorausrobotik.sources` + `keyrings/vorausrobotik.asc` written |
| Second run | `changed=0` |
| Host with a conflicting `Signed-By` | `apt` broken beforehand, repaired by the run, `apt-get update` green afterwards |
| Package install | `apt-get update` verifies the release file, `codemeter-lite 9.10.8166.500` installs |

`ansible-lint` passes the repository's `production` profile.

## Not in this PR

All Molecule platforms remain Debian 13. Adding a Debian 12 host would exercise the one-line
migration path on an older release, but costs another VM per run; deliberately left out.
